### PR TITLE
HTTPGatewaySpec works with base_url as attribute instead of metaclass arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ class ResponseBody(BaseModel):
 
 
 gateway = DefaultHTTPRequestGateway(
-    http_session=DefaultHttpSession(),
+    session=DefaultHttpSession(),
     url="https://httpbin.org/post",
     method=HTTPMethod.POST,
     request_adapter=DefaultHTTPRequestAdapter(model=RequestBody),

--- a/apikit/default.py
+++ b/apikit/default.py
@@ -104,7 +104,7 @@ class DefaultHTTPRequestGateway(HTTPRequestGateway, Generic[T, Q]):
     """_summary_
 
     Args:
-        http_session (HttpSession): To handle the request.
+        session (HttpSession): To handle the request.
         url (str): Complete URL without the query params.
         method (HTTPMethod): GET, POST, PUT, etc.
         headers (Optional[dict], optional): The same key/values requests can handle.
@@ -118,14 +118,14 @@ class DefaultHTTPRequestGateway(HTTPRequestGateway, Generic[T, Q]):
     def __init__(
         self,
         *,
-        http_session: HttpSession,
+        session: HttpSession,
         url: str,
         method: HTTPMethod,
         headers: Optional[dict] = None,
         request_adapter: Optional[HTTPRequestAdapter[type[T]]] = None,
         response_adapter: Optional[HTTPResponseAdapter[type[Q]]] = None,
     ):
-        self.session = http_session
+        self.session = session
         self.url = url
         self.method = method
         self.request_adapter = request_adapter or DefaultHTTPRequestAdapter()

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -203,7 +203,7 @@ def test_http_request_adapter_for_get(model, instance, session, url, headers):
 def test_http_request_gateway_prepare_get(model, instance, session, url, headers):
     method = HTTPMethod.GET
     gateway = DefaultHTTPRequestGateway(
-        http_session=session,
+        session=session,
         url=url,
         method=method,
         request_adapter=DefaultHTTPRequestAdapter(model),
@@ -230,7 +230,7 @@ def test_http_request_gateway_prepare_get(model, instance, session, url, headers
 def test_http_request_gateway_prepare_post(model, instance, session, url, headers):
     method = HTTPMethod.POST
     gateway = DefaultHTTPRequestGateway(
-        http_session=session,
+        session=session,
         url=url,
         method=method,
         request_adapter=DefaultHTTPRequestAdapter(model),
@@ -259,7 +259,7 @@ def test_http_request_gateway_receive_post(
 ):
     method = HTTPMethod.POST
     gateway = DefaultHTTPRequestGateway(
-        http_session=session,
+        session=session,
         url=url,
         method=method,
         request_adapter=...,
@@ -284,7 +284,7 @@ def test_http_request_gateway_receive_get(
 ):
     method = HTTPMethod.GET
     gateway = DefaultHTTPRequestGateway(
-        http_session=session,
+        session=session,
         url=url,
         method=method,
         request_adapter=...,
@@ -307,7 +307,7 @@ def test_http_request_gateway_receive_get(
 def test_http_request_gateway_execute_get(model, instance, session, url, headers):
     method = HTTPMethod.GET
     gateway = DefaultHTTPRequestGateway(
-        http_session=session,
+        session=session,
         url=url,
         method=method,
         request_adapter=DefaultHTTPRequestAdapter(model),
@@ -334,7 +334,7 @@ def test_http_request_gateway_execute_get(model, instance, session, url, headers
 def test_http_request_gateway_execute_post(model, instance, session, url, headers):
     method = HTTPMethod.POST
     gateway = DefaultHTTPRequestGateway(
-        http_session=session,
+        session=session,
         url=url,
         method=method,
         request_adapter=DefaultHTTPRequestAdapter(model),

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from apikit.session import StaticTokenSessionAuthorizer
 import pytest
 from apikit.default import (
@@ -6,6 +5,7 @@ from apikit.default import (
     DefaultHTTPRequestGateway,
     DefaultHTTPResponseAdapter,
 )
+from apikit.session import DefaultHttpSession
 from apikit.protocols import (
     HTTPMethod,
     HTTPRequestAdapter,
@@ -24,7 +24,7 @@ def test_http_gateway_spec_init_with_none_url():
 
 
 def test_http_gateway_spec_init_with_no_url():
-    with pytest.raises(TypeError):
+    with pytest.raises(AssertionError):
         HTTPGatewaySpec(method=HTTPMethod.GET)
 
 
@@ -34,23 +34,23 @@ def test_http_gateway_spec_init_with_none_method():
 
 
 def test_http_gateway_spec_init_no_method():
-    with pytest.raises(TypeError):
+    with pytest.raises(AssertionError):
         HTTPGatewaySpec(url="https://test.com")
 
 
 def test_http_gateway_spec_init_with_default_http_request():
     spec = HTTPGatewaySpec(url="https://test.com", method=HTTPMethod.GET)
-    assert isinstance(spec.request, DefaultHTTPRequestGateway)
+    assert isinstance(spec.gateway, DefaultHTTPRequestGateway)
 
 
 def test_http_gateway_spec_init_with_default_http_request_adapter():
     spec = HTTPGatewaySpec(url="https://test.com", method=HTTPMethod.GET)
-    assert isinstance(spec.request.request_adapter, DefaultHTTPRequestAdapter)
+    assert isinstance(spec.gateway.request_adapter, DefaultHTTPRequestAdapter)
 
 
 def test_http_gateway_spec_init_with_default_http_response_adapter():
     spec = HTTPGatewaySpec(url="https://test.com", method=HTTPMethod.GET)
-    assert isinstance(spec.request.response_adapter, DefaultHTTPResponseAdapter)
+    assert isinstance(spec.gateway.response_adapter, DefaultHTTPResponseAdapter)
 
 
 def test_http_gateway_spec_init_with_override_http_request_adapter_class():
@@ -61,7 +61,7 @@ def test_http_gateway_spec_init_with_override_http_request_adapter_class():
         method=HTTPMethod.GET,
         request_adapter=TestHTTPRequestAdapter,
     )
-    assert isinstance(spec.request.request_adapter, TestHTTPRequestAdapter)
+    assert isinstance(spec.gateway.request_adapter, TestHTTPRequestAdapter)
 
 
 def test_http_gateway_spec_init_with_override_http_response_adapter_class():
@@ -72,7 +72,7 @@ def test_http_gateway_spec_init_with_override_http_response_adapter_class():
         method=HTTPMethod.GET,
         response_adapter=TestHTTPResponseAdapter,
     )
-    assert isinstance(spec.request.response_adapter, TestHTTPResponseAdapter)
+    assert isinstance(spec.gateway.response_adapter, TestHTTPResponseAdapter)
 
 
 def test_http_gateway_spec_init_with_override_http_request_adapter_instance():
@@ -83,7 +83,7 @@ def test_http_gateway_spec_init_with_override_http_request_adapter_instance():
         method=HTTPMethod.GET,
         request_adapter=TestHTTPRequestAdapter(),
     )
-    assert isinstance(spec.request.request_adapter, TestHTTPRequestAdapter)
+    assert isinstance(spec.gateway.request_adapter, TestHTTPRequestAdapter)
 
 
 def test_http_gateway_spec_init_with_override_http_response_adapter_instance():
@@ -94,7 +94,7 @@ def test_http_gateway_spec_init_with_override_http_response_adapter_instance():
         method=HTTPMethod.GET,
         response_adapter=TestHTTPResponseAdapter(),
     )
-    assert isinstance(spec.request.response_adapter, TestHTTPResponseAdapter)
+    assert isinstance(spec.gateway.response_adapter, TestHTTPResponseAdapter)
 
 
 def test_http_gateway_spec_get():
@@ -107,28 +107,138 @@ def test_http_gateway_spec_get():
 
 def test_http_gateway_get_spec_init():
     spec = HTTPGatewayGETSpec(url="https://test.com")
-    assert spec.request.method == HTTPMethod.GET
+    assert spec.gateway.method == HTTPMethod.GET
 
 
 def test_http_gateway_post_spec_init():
     spec = HTTPGatewayPOSTSpec(url="https://test.com")
-    assert spec.request.method == HTTPMethod.POST
+    assert spec.gateway.method == HTTPMethod.POST
 
 
-def test_http_gateway_spec_base_url():
-    class TestHTTPGatewaySpec(HTTPGatewaySpec, base_url="https://test.com"):
-        url = "/test"
-        method = HTTPMethod.GET
-
-    spec = TestHTTPGatewaySpec()
-    assert spec.request.url == "https://test.com/test"
-
-
-def test_Http_gateway_spec_init_with_authorizer():
-    class TestHTTPGatewaySpec(HTTPGatewaySpec, base_url="https://test.com"):
-        url = "/test"
+def test_http_gateway_spec_init_with_authorizer():
+    class TestHTTPGatewaySpec(HTTPGatewaySpec):
+        url = "https://test.com/test"
         method = HTTPMethod.GET
         authorizer = StaticTokenSessionAuthorizer(token="test_token")
 
     spec = TestHTTPGatewaySpec()
-    assert spec.request.session.auth.token == "test_token"
+    assert spec.gateway.session.auth.token == "test_token"
+
+
+def test_http_gateway_spec_init_with_base_url():
+    class TestHTTPGatewaySpec(
+        HTTPGatewaySpec,
+    ):
+        base_url = "https://test.com"
+        method = HTTPMethod.GET
+
+    spec = TestHTTPGatewaySpec(url="/test")
+    assert spec.gateway.url == "https://test.com/test"
+
+
+def test_http_gateway_spec_init_with_invalid_url():
+    class TestHTTPGatewaySpec(
+        HTTPGatewaySpec,
+    ):
+        method = HTTPMethod.GET
+
+    with pytest.raises(ValueError):
+        spec = TestHTTPGatewaySpec(url="/test")
+
+
+def test_http_gateway_spec_inheritance_with_with_base_url():
+    class TestHTTPGatewaySpec(
+        HTTPGatewaySpec,
+    ):
+        base_url = "https://test.com"
+        method = HTTPMethod.GET
+        response_model = object
+
+    class TestChildHTTPGatewaySpec(TestHTTPGatewaySpec): ...
+
+    spec = TestChildHTTPGatewaySpec(url="/test")
+    assert spec.gateway.url == "https://test.com/test"
+
+
+def test_http_gateway_spec_inheritance_with_method_attribute():
+    class TestHTTPGatewaySpec(
+        HTTPGatewaySpec,
+    ):
+        method = HTTPMethod.GET
+
+    class TestChildHTTPGatewaySpec(TestHTTPGatewaySpec): ...
+
+    spec = TestChildHTTPGatewaySpec(url="https://test.com")
+    assert spec.gateway.method == HTTPMethod.GET
+
+
+def test_http_gateway_spec_inheritance_with_request_adapter_attribute():
+    class TestDefaultHTTPRequestAdapter(HTTPRequestAdapter): ...
+
+    class TestHTTPGatewaySpec(
+        HTTPGatewaySpec,
+    ):
+        method = HTTPMethod.GET
+        request_adapter = TestDefaultHTTPRequestAdapter
+
+    class TestChildHTTPGatewaySpec(TestHTTPGatewaySpec): ...
+
+    spec = TestChildHTTPGatewaySpec(url="https://test.com")
+    assert isinstance(spec.gateway.request_adapter, TestDefaultHTTPRequestAdapter)
+
+
+def test_http_gateway_spec_inheritance_with_response_adapter_attribute():
+    class TestDefaultHTTPResponseAdapter(HTTPResponseAdapter): ...
+
+    class TestHTTPGatewaySpec(
+        HTTPGatewaySpec,
+    ):
+        method = HTTPMethod.GET
+        response_adapter = TestDefaultHTTPResponseAdapter
+
+    class TestChildHTTPGatewaySpec(TestHTTPGatewaySpec): ...
+
+    spec = TestChildHTTPGatewaySpec(url="https://test.com")
+    assert isinstance(spec.gateway.response_adapter, TestDefaultHTTPResponseAdapter)
+
+
+def test_http_gateway_spec_inheritance_with_authorizer():
+    class TestHTTPGatewaySpec(HTTPGatewaySpec):
+        url = "https://test.com/test"
+        method = HTTPMethod.GET
+        authorizer = StaticTokenSessionAuthorizer(token="test_token")
+
+    class TestChildHTTPGatewaySpec(TestHTTPGatewaySpec): ...
+
+    spec = TestChildHTTPGatewaySpec()
+    assert spec.gateway.session.auth.token == "test_token"
+
+
+def test_http_gateway_spec_inheritance_with_session_attribute():
+    class TestHTTPSession(DefaultHttpSession): ...
+
+    class TestHTTPGatewaySpec(
+        HTTPGatewaySpec,
+    ):
+        method = HTTPMethod.GET
+        session = TestHTTPSession
+
+    class TestChildHTTPGatewaySpec(TestHTTPGatewaySpec): ...
+
+    spec = TestChildHTTPGatewaySpec(url="https://test.com")
+    assert isinstance(spec.gateway.session, TestHTTPSession)
+
+
+def test_http_gateway_spec_inheritance_with_gateway_attribute():
+    class TestHTTPGateway(DefaultHTTPRequestGateway): ...
+
+    class TestHTTPGatewaySpec(
+        HTTPGatewaySpec,
+    ):
+        method = HTTPMethod.GET
+        gateway = TestHTTPGateway
+
+    class TestChildHTTPGatewaySpec(TestHTTPGatewaySpec): ...
+
+    spec = TestChildHTTPGatewaySpec(url="https://test.com")
+    assert isinstance(spec.gateway, TestHTTPGateway)


### PR DESCRIPTION
Also, fixes a issue that prevented attributes from parent GatewaySpecs to reflet in the created gateway when doing inheritance.