### PR TITLE
Changes poetry installation mode so it doesn't pick yanked libs

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install poetry
+        python -m pip install poetry==N
         poetry install
     - name: Test with pytest
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install poetry==N
+        python -m pip install poetry==1.8.3
         poetry install
     - name: Test with pytest
       run: |


### PR DESCRIPTION
The last PR (https://github.com/Arbeit-Studio/apikit/pull/7) broke because of a library called filelock-3.15.2.

Following this thread https://github.com/tox-dev/filelock/issues/337, we can see that the library is now considered 'yanked.'

One of the suggested workarounds proposes that we fix the Poetry version, so while building, it won't select any yanked libraries.