### PR TITLE
Refactor HTTP request handling to include timeout parameter and update related tests

### DIFF
--- a/apikit/specs.py
+++ b/apikit/specs.py
@@ -1,8 +1,15 @@
 from functools import partialmethod
 from inspect import isclass
 from typing import Optional, Union
-from typing_extensions import dataclass_transform
 from urllib.parse import urlparse
+
+from typing_extensions import dataclass_transform
+
+from apikit.default import (
+    DefaultHTTPRequestAdapter,
+    DefaultHTTPRequestGateway,
+    DefaultHTTPResponseAdapter,
+)
 from apikit.protocols import (
     HTTPMethod,
     HTTPRequestAdapter,
@@ -10,15 +17,7 @@ from apikit.protocols import (
     HTTPResponseAdapter,
     HttpSession,
 )
-from apikit.session import (
-    DefaultHttpSession,
-    StaticTokenSessionAuthorizer,
-)
-from apikit.default import (
-    DefaultHTTPRequestAdapter,
-    DefaultHTTPRequestGateway,
-    DefaultHTTPResponseAdapter,
-)
+from apikit.session import DefaultHttpSession, StaticTokenSessionAuthorizer
 
 
 def get_url(base_url, url):
@@ -42,6 +41,7 @@ def _init_fn(
     url: str = None,
     method: HTTPMethod = None,
     base_url: Optional[str] = "",
+    timeout: Optional[int] = None,
     request_adapter: Union[HTTPRequestAdapter, type[HTTPRequestAdapter]] = None,
     response_adapter: Union[HTTPResponseAdapter, type[HTTPResponseAdapter]] = None,
     request_model=None,
@@ -130,6 +130,7 @@ def _init_fn(
         session=initialized_session,
         url=url,
         method=method,
+        timeout=timeout,
         request_adapter=initialized_request_adapter,
         response_adapter=initialized_response_adapter,
     )
@@ -151,6 +152,7 @@ class HTTPGatewaySpec(metaclass=MetaSpec):
         url: str = None,
         method: HTTPMethod = None,
         base_url: Optional[str] = "",
+        timeout: Optional[int] = None,
         request_adapter: Union[HTTPRequestAdapter, type[HTTPRequestAdapter]] = None,
         response_adapter: Union[HTTPResponseAdapter, type[HTTPResponseAdapter]] = None,
         request_model=None,
@@ -165,6 +167,7 @@ class HTTPGatewaySpec(metaclass=MetaSpec):
             url=url,
             method=method,
             base_url=base_url,
+            timeout=timeout,
             request_adapter=request_adapter,
             response_adapter=response_adapter,
             request_model=request_model,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "apikit"
- version = "0.1.4"
+version = "0.1.5"
 description = "A requests + pydantic based kit to save you the trouble."
 authors = ["Johnny Wellington <johnny@arbeitstudio.com.br>"]
 license = "apache-2.0"

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,22 +1,14 @@
 from unittest.mock import Mock
+
 import pytest
 from requests import Request
+
 from apikit.session import (
     BearerTokenAuth,
     DefaultCachedHttpSession,
     DefaultHttpSession,
     StaticTokenSessionAuthorizer,
 )
-
-
-@pytest.mark.parametrize(
-    "read_timeout, expectativa",
-    [(120, (3.5, 120)), (60, (3.5, 60)), (None, (3.5, 60)), (5, (3.5, 5))],
-)
-def test_default_http_session_timeout(read_timeout, expectativa):
-    """Testa se a session é criada com o timeout informado ou default"""
-    test_i4pro_http_session = DefaultHttpSession(read_timeout=read_timeout)
-    assert test_i4pro_http_session.request.keywords["timeout"] == expectativa
 
 
 def test_static_token_session_authorizer():
@@ -43,24 +35,21 @@ def test_bearer_token_auth():
 
 def test_default_http_session_from_context():
 
-    read_timeout = 90
-    test_session = DefaultHttpSession.from_context(
-        context=Mock(), read_timeout=read_timeout
-    )
-    test_session_key = DefaultHttpSession._context_key(read_timeout)
+    test_session = DefaultHttpSession.from_context(context=Mock())
+    test_session_key = DefaultHttpSession._context_key()
     assert hasattr(test_session, test_session_key)
 
 
 def test_default_http_session__initialize_without_authorizer():
-    session = DefaultHttpSession._initialize(authorizer=None, read_timeout=90)
+    session = DefaultHttpSession._initialize(
+        authorizer=None,
+    )
     assert session.auth is None
 
 
 def test_default_http_session__initialize_with_authorizer():
     test_authorizer = StaticTokenSessionAuthorizer(token="test_token")
-    session = DefaultHttpSession._initialize(
-        authorizer=test_authorizer, read_timeout=90
-    )
+    session = DefaultHttpSession._initialize(authorizer=test_authorizer)
     assert session.auth
 
 


### PR DESCRIPTION
This pull request introduces significant refactoring and enhancements to the `apikit` library, including changes to the request handling logic, the introduction of a `timeout` parameter, and updates to the test suite. The most important updates include replacing the `HTTPRequest` protocol with `HTTPRequestParams`, adding support for timeouts, and simplifying the session initialization logic.

### Request Handling Enhancements:
* Replaced the `HTTPRequest` protocol with a `TypedDict` called `HTTPRequestParams` to simplify request parameter management. This includes fields like `url`, `method`, `headers`, `timeout`, `json`, and `params` ([[1]](diffhunk://#diff-5f044926addb1da73d1ed34186b46e27fe6ba57c9019c77298117dd42431a0a2L17-R24), [[2]](diffhunk://#diff-bbf19a548a3562883ac35f88dbf51375d7cb6e479d8d24221737cb7519deeeecL87-R108)).
* Updated the `adapt` method in `HTTPRequestAdapter` and `prepare` method in `HTTPRequestGateway` to return `HTTPRequestParams` instead of a prepared request object. This change decouples request preparation from session handling ([apikit/default.pyL87-R108](diffhunk://#diff-bbf19a548a3562883ac35f88dbf51375d7cb6e479d8d24221737cb7519deeeecL87-R108), `F8156948L83R36`).

### Timeout Support:
* Introduced an optional `timeout` parameter to the `HTTPRequestAdapter`, `HTTPRequestGateway`, and related methods, allowing for custom timeout configurations for HTTP requests ([[1]](diffhunk://#diff-bbf19a548a3562883ac35f88dbf51375d7cb6e479d8d24221737cb7519deeeecR132), [[2]](diffhunk://#diff-e4e8ba8f1e954bce844b571174e5173d64208804e26403fcb68271176f9cf344R44)).
* Removed the default `read_timeout` logic from `DefaultHttpSession` and `DefaultCachedHttpSession`, streamlining session initialization without hardcoding timeouts ([[1]](diffhunk://#diff-8042d2c0312919f4d3e31f83cff1fe67ee49005ef14183c3c69c5c3e2577374bL47-R82), [[2]](diffhunk://#diff-8042d2c0312919f4d3e31f83cff1fe67ee49005ef14183c3c69c5c3e2577374bL102-L119)).

### Session Simplification:
* Simplified session initialization by removing the `read_timeout` parameter and related logic. This reduces complexity and delegates timeout handling to the request layer ([[1]](diffhunk://#diff-8042d2c0312919f4d3e31f83cff1fe67ee49005ef14183c3c69c5c3e2577374bL47-R82), [[2]](diffhunk://#diff-8042d2c0312919f4d3e31f83cff1fe67ee49005ef14183c3c69c5c3e2577374bL102-L119)).
* Updated the `HttpSession` protocol to include a `request` method, aligning it with the new `HTTPRequestParams` structure ([apikit/protocols.pyR39-R59](diffhunk://#diff-5f044926addb1da73d1ed34186b46e27fe6ba57c9019c77298117dd42431a0a2R39-R59)).

### Test Suite Updates:
* Refactored tests to align with the new `HTTPRequestParams` structure. Assertions now validate the contents of the `HTTPRequestParams` dictionary rather than the attributes of a prepared request object ([[1]](diffhunk://#diff-53081d531f0193efbce5924a400ccbb2f65e05d0361c22c555869d6d9e16253fL154-R149), [[2]](diffhunk://#diff-53081d531f0193efbce5924a400ccbb2f65e05d0361c22c555869d6d9e16253fL213-R201)).
* Removed outdated tests related to `read_timeout` in sessions, as timeout handling has been moved to the request layer ([tests/test_session.pyL12-L21](diffhunk://#diff-3121d1f70912305d7e409dfd557f34d9f5869a86d8d347b0a4cca1e1c124df42L12-L21)).

### Code Cleanup:
* Removed unused imports, redundant methods, and outdated comments for improved code clarity and maintainability ([[1]](diffhunk://#diff-53081d531f0193efbce5924a400ccbb2f65e05d0361c22c555869d6d9e16253fL80-L91), [[2]](diffhunk://#diff-e4e8ba8f1e954bce844b571174e5173d64208804e26403fcb68271176f9cf344L4-R20)).

These changes collectively enhance the flexibility, maintainability, and testability of the `apikit` library while introducing support for configurable timeouts.